### PR TITLE
Fix issue #48 DocumentDB connection string is not correctly parsed when last character is semicolon

### DIFF
--- a/app/com/microsoft/azure/iotsolutions/storageadapter/services/wrappers/DocumentClientFactory.java
+++ b/app/com/microsoft/azure/iotsolutions/storageadapter/services/wrappers/DocumentClientFactory.java
@@ -114,7 +114,7 @@ public class DocumentClientFactory implements IFactory<DocumentClient> {
     }
 
     private static String getDocumentDbUri(String DocumentDbConnString) {
-        Pattern pattern = Pattern.compile(".*AccountEndpoint=(.*);.*");
+        Pattern pattern = Pattern.compile(".*AccountEndpoint=(.*);.*;");
         Matcher matcher = pattern.matcher(DocumentDbConnString);
         if (matcher.find()) {
             return matcher.group(1);


### PR DESCRIPTION
DocumentDB connection string is not correctly parsed when last character is semicolon

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->


**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
